### PR TITLE
feat: add kintone-customize-es5

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,16 @@ In order to this, you have to install `prettier` and choose a preset from the fo
 - `@cybouz/eslint-config/presets/es5-prettier`
 
 **Currently, we don't support customized Prettier config**
+
+## For kintone customize developers
+
+`@cybozu/eslint-config/preset/kintone-customize-es5` is a preset for kintone customize(plug-in) developers, which is based on `preset/es5` and add some `globals` for kintone.
+
+```js
+module.exports = {
+  extends:
+    "@cybozu/eslint-config/presets/@cybozu/eslint-config/preset/kintone-customize-es5"
+};
+```
+
+We also provide `@cybozu/eslint-config/presets/@cybozu/eslint-config/preset/kintone-customize-es5` to use it with `prettier`.

--- a/globals/kintone.js
+++ b/globals/kintone.js
@@ -1,0 +1,18 @@
+// Taken from https://github.com/kintone/eslint-config-kintone
+module.exports = {
+  globals: {
+    $: false,
+    jQuery: false,
+    kintone: false,
+    moment: false,
+    Handsontable: false,
+    hljs: false,
+    marked: false,
+    sweetAlert: false,
+    swal: false,
+    Chart: false,
+    DOMPurify: false,
+    Spinner: false,
+    UltraDate: false
+  }
+};

--- a/lib/kintone.js
+++ b/lib/kintone.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    strict: ["error", "function"]
+  }
+};

--- a/presets/kintone-customize-es5-prettier.js
+++ b/presets/kintone-customize-es5-prettier.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: [
+    "../lib/es5.js",
+    "../lib/kintone.js",
+    "../globals/kintone.js",
+    "../lib/prettier.js"
+  ]
+};

--- a/presets/kintone-customize-es5.js
+++ b/presets/kintone-customize-es5.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["../lib/es5.js", "../lib/kintone.js", "../globals/kintone.js"]
+};

--- a/test/fixtures/es5/ok.js
+++ b/test/fixtures/es5/ok.js
@@ -1,4 +1,7 @@
-var foos = [''];
-foos.map(function(foo) {
-  return foo + foo;
-});
+(function() {
+  'use strict';
+  var foos = [''];
+  foos.map(function(foo) {
+    return foo + foo;
+  });
+}());

--- a/test/fixtures/es5/warning.js
+++ b/test/fixtures/es5/warning.js
@@ -1,8 +1,11 @@
-var a = 1;
-var b = 2;
+(function() {
+  'use strict';
+  var a = 1;
+  var b = 2;
 
-alert(a + b);
+  alert(a + b);
 
-[].map(function(v) {
-  alert(v);
-});
+  [].map(function(v) {
+    alert(v);
+  });
+}());

--- a/test/fixtures/globals-kintone/error.js
+++ b/test/fixtures/globals-kintone/error.js
@@ -1,0 +1,2 @@
+/*eslint no-undef: "error"*/
+unknown();

--- a/test/fixtures/globals-kintone/ok.js
+++ b/test/fixtures/globals-kintone/ok.js
@@ -1,0 +1,4 @@
+/*eslint no-undef: "error"*/
+$('<div />');
+
+moment();

--- a/test/fixtures/kintone/error.js
+++ b/test/fixtures/kintone/error.js
@@ -1,0 +1,10 @@
+(function() {
+  var a = '';
+  alert(a);
+}());
+
+
+function foo() {
+}
+
+foo();

--- a/test/fixtures/kintone/ok.js
+++ b/test/fixtures/kintone/ok.js
@@ -1,0 +1,12 @@
+(function() {
+  'use strict';
+  var a = '';
+  alert(a);
+}());
+
+
+function foo() {
+  'use strict';
+}
+
+foo();

--- a/test/globals-kintone-test.js
+++ b/test/globals-kintone-test.js
@@ -1,0 +1,14 @@
+const assert = require("assert");
+const runLintWithFixtures = require("./lib/runLintWithFixtures");
+
+describe("kintone", () => {
+  it("should get expected errors and warninigs with kintone config", () => {
+    const result = runLintWithFixtures("globals-kintone", "globals/kintone.js");
+    assert.deepStrictEqual(result, {
+      "error.js": {
+        errors: ["no-undef"]
+      },
+      "ok.js": {}
+    });
+  });
+});

--- a/test/kintone-test.js
+++ b/test/kintone-test.js
@@ -1,0 +1,14 @@
+const assert = require("assert");
+const runLintWithFixtures = require("./lib/runLintWithFixtures");
+
+describe("kintone", () => {
+  it("should get expected errors and warninigs with kintone config", () => {
+    const result = runLintWithFixtures("kintone");
+    assert.deepStrictEqual(result, {
+      "error.js": {
+        errors: ["strict", "strict"]
+      },
+      "ok.js": {}
+    });
+  });
+});

--- a/test/presets-test.js
+++ b/test/presets-test.js
@@ -69,4 +69,21 @@ describe("presets", () => {
       );
     });
   });
+  describe("kintone-customize-es5", () => {
+    it("should be able to use kintone-customize-es5 as well as lib/es5 and lib/kintone", () => {
+      assert.deepStrictEqual(
+        runLintWithFixtures("es5"),
+        runLintWithFixtures("es5", "presets/kintone-customize-es5.js")
+      );
+    });
+    it("should be able to use kintone-customize-es5 as well as lib/kintone", () => {
+      assert.deepStrictEqual(
+        runLintWithFixtures("kintone", "presets/kintone-customize-es5.js"),
+        {
+          "ok.js": {},
+          "error.js": { errors: ["strict", "strict"] }
+        }
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces `kintone-customize-es5`, which is for developers of kintone customize(plugins).
You can use `kintone-customize-es5` as `@cybozu/eslint-config/presets/kintone-customize-es5`.