### PR TITLE
feat: allow $.Deferred for new-cap

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -213,7 +213,7 @@ module.exports = {
     "max-nested-callbacks": ["warn", 5],
     "max-params": ["warn", 7],
     "max-statements": ["warn", 40],
-    "new-cap": ["warn", { capIsNewExceptions: ["$.Deferred"] }],
+    "new-cap": ["warn", { capIsNewExceptions: ["Deferred"] }],
     "no-array-constructor": "warn",
     "no-lonely-if": "warn",
     "no-multiple-empty-lines": [

--- a/lib/base.js
+++ b/lib/base.js
@@ -213,7 +213,7 @@ module.exports = {
     "max-nested-callbacks": ["warn", 5],
     "max-params": ["warn", 7],
     "max-statements": ["warn", 40],
-    "new-cap": "warn",
+    "new-cap": ["warn", { capIsNewExceptions: ["$.Deferred"] }],
     "no-array-constructor": "warn",
     "no-lonely-if": "warn",
     "no-multiple-empty-lines": [

--- a/test/fixtures/base/ok.js
+++ b/test/fixtures/base/ok.js
@@ -7,3 +7,9 @@ async function hoge() {
   return result;
 }
 hoge();
+
+const $ = {
+  Deferred: function() {}
+};
+
+$.Deferred();

--- a/test/fixtures/base/ok.js
+++ b/test/fixtures/base/ok.js
@@ -1,3 +1,5 @@
+/* eslint-env jquery */
+
 const foos = [''];
 foos.map((foo) => foo + foo);
 
@@ -8,8 +10,5 @@ async function hoge() {
 }
 hoge();
 
-const $ = {
-  Deferred: function() {}
-};
-
 $.Deferred();
+jQuery.Deferred();


### PR DESCRIPTION
I've noticed that `$.Deferred()` is reported as `new-cap` violation so I want to add `capIsNewExceptions` for `$.Deferred()`