### PR TITLE
fix(perf): typescript: disable rules required type infomation

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -2,18 +2,20 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   extends: ["plugin:@typescript-eslint/recommended"],
+  // It's 5〜10x slower with the project setting.
+  // So We disable it until the issue has been fixed
+  /*
   parserOptions: {
     project: "./tsconfig.json"
   },
+  */
   rules: {
     "@typescript-eslint/array-type": ["error", "array-simple"],
-    "@typescript-eslint/no-for-in-array": "error",
 
     "no-useless-constructor": "off",
     "@typescript-eslint/no-useless-constructor": "warn",
     "@typescript-eslint/type-annotation-spacing": "warn",
     "@typescript-eslint/unified-signatures": "warn",
-    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
     "@typescript-eslint/indent": ["warn", 2, { SwitchCase: 1 }],
 
     "@typescript-eslint/camelcase": "off",
@@ -31,5 +33,10 @@ module.exports = {
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/prefer-interface": "off",
     "@typescript-eslint/prefer-namespace-keyword": "off"
+
+    // These rules are required type information,
+    // which means these can be checked without parserOptions.project
+    // "@typescript-eslint/no-for-in-array": "error",
+    // "@typescript-eslint/no-unnecessary-type-assertion": "warn",
   }
 };

--- a/test/react-typescript-test.js
+++ b/test/react-typescript-test.js
@@ -14,10 +14,7 @@ describe("react-typescript", () => {
         errors: ["@typescript-eslint/array-type"]
       },
       "warning.tsx": {
-        warnings: [
-          "@typescript-eslint/no-useless-constructor",
-          "@typescript-eslint/no-unnecessary-type-assertion"
-        ]
+        warnings: ["@typescript-eslint/no-useless-constructor"]
       }
     });
   });

--- a/test/typescript-test.js
+++ b/test/typescript-test.js
@@ -11,10 +11,7 @@ describe("typescript", () => {
         errors: ["@typescript-eslint/array-type"]
       },
       "warning.ts": {
-        warnings: [
-          "@typescript-eslint/no-useless-constructor",
-          "@typescript-eslint/no-unnecessary-type-assertion"
-        ]
+        warnings: ["@typescript-eslint/no-useless-constructor"]
       }
     });
   });


### PR DESCRIPTION
We've added TypeScript support as #97, which is enabled rules that is required type information so we have to add `parserOptions.project` into our `.eslintrc.js`.
But lint with the option is 5〜10x slower than without it, which is not an  acceptable regression for us so we've decided to disable all rules required type information.
