### PR TITLE
Add react-hooks and jsx-a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module.exports = {
 - `@cybozu/eslint-config/presets/typescript`
   - Including `@typescript-eslint/eslint-plugin`
 - `@cybozu/eslint-config/presets/react`
-  - Including `eslint-plugin-react` and `eslint-plugin-jsx-ally`
+  - Including `eslint-plugin-react`, `eslint-plugin-jsx-ally` and `eslint-plugin-react-hooks`
 - `@cybozu/eslint-config/presets/react-typescript`
   - Including `@cybozu/eslint-config/presets/typescript` and `@cybozu/eslint-config/presets/react`
 - `@cybozu/eslint-config/presets/flowtype`
@@ -128,4 +128,3 @@ module.exports = {
 ```
 
 We also provide `@cybozu/eslint-config/presets/kintone-customize-es5-prettier` to use it with `prettier`.
-

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ module.exports = {
   - Including `@typescript-eslint/eslint-plugin`
 - `@cybozu/eslint-config/presets/react`
   - Including `eslint-plugin-react`, `eslint-plugin-jsx-ally` and `eslint-plugin-react-hooks`
+  - ⚠️ A11y rules are being defined as warnings, which is an experimental so we might change the rules in later
 - `@cybozu/eslint-config/presets/react-typescript`
   - Including `@cybozu/eslint-config/presets/typescript` and `@cybozu/eslint-config/presets/react`
 - `@cybozu/eslint-config/presets/flowtype`

--- a/lib/base.js
+++ b/lib/base.js
@@ -349,6 +349,7 @@ module.exports = {
     // no-inline-comments
     // no-multi-assign
     // no-negated-condition
+    // prefer-named-capture-group
     // prefer-object-spread
     // no-plusplus
     // no-restricted-syntax

--- a/lib/react.js
+++ b/lib/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ["react", "react-hooks"],
+  plugins: ["react", "react-hooks", "jsx-a11y"],
   extends: ["plugin:react/recommended"],
   parserOptions: {
     ecmaFeatures: {
@@ -134,6 +134,42 @@ module.exports = {
     // Hooks
     // =======
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+
+    // =======
+    // a11y
+    // =======
+    // jsx-a11y/accessible-emoji:
+    "jsx-a11y/alt-text": "warn",
+    "jsx-a11y/anchor-has-content": "warn",
+    "jsx-a11y/anchor-is-valid": "warn",
+    "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
+    "jsx-a11y/aria-props": "warn",
+    "jsx-a11y/aria-role": "warn",
+    "jsx-a11y/aria-unsupported-elements": "warn",
+    "jsx-a11y/click-events-have-key-events": "warn",
+    "jsx-a11y/heading-has-content": "warn",
+    "jsx-a11y/html-has-lang": "error",
+    "jsx-a11y/iframe-has-title": "warn",
+    // jsx-a11y/img-redundant-alt
+    "jsx-a11y/interactive-supports-focus": "warn",
+    "jsx-a11y/label-has-associated-control": "warn",
+    "jsx-a11y/lang": "error",
+    "jsx-a11y/media-has-caption": "warn",
+    "jsx-a11y/mouse-events-have-key-events": "warn",
+    "jsx-a11y/no-access-key": "warn",
+    "jsx-a11y/no-autofocus": "warn",
+    "jsx-a11y/no-distracting-elements": "warn",
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": "warn",
+    "jsx-a11y/no-noninteractive-element-interactions": "warn",
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": "warn",
+    "jsx-a11y/no-noninteractive-tabindex": "warn",
+    "jsx-a11y/no-redundant-roles": "warn",
+    // jsx-a11y/no-onchange
+    "jsx-a11y/no-static-element-interactions": "warn",
+    "jsx-a11y/role-has-required-aria-props": "warn",
+    "jsx-a11y/role-supports-aria-props": "warn",
+    "jsx-a11y/scope": "warn",
+    "jsx-a11y/tabindex-no-positive": "warn"
   }
 };

--- a/lib/react.js
+++ b/lib/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ["react"],
+  plugins: ["react", "react-hooks"],
   extends: ["plugin:react/recommended"],
   parserOptions: {
     ecmaFeatures: {
@@ -94,7 +94,7 @@ module.exports = {
         afterOpening: "never"
       }
     ],
-    "react/jsx-wrap-multilines": "warn"
+    "react/jsx-wrap-multilines": "warn",
 
     // =======
     // None
@@ -129,5 +129,11 @@ module.exports = {
     // react/jsx-sort-default-props
     // react/jsx-sort-props
     // react/jsx-space-before-closing deprecated
+
+    // =======
+    // Hooks
+    // =======
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 };

--- a/lib/react.js
+++ b/lib/react.js
@@ -85,6 +85,7 @@ module.exports = {
       { props: "never", children: "never" }
     ],
     "react/jsx-pascal-case": ["warn", { allowAllCaps: true }],
+    "react/jsx-props-no-multi-spaces": "warn",
     "react/jsx-tag-spacing": [
       "warn",
       {
@@ -112,9 +113,11 @@ module.exports = {
     // react/no-set-state
     // react/no-unused-prop-types doesn't track destructuring and assignment props so we are disable this.
     // react/no-unused-prop-types
+    // react/no-unsafe
     // react/require-default-props
     // react/require-optimization
     // react/sort-prop-type
+    // react/state-in-constructor
 
     // react/jsx-child-element-spacing
     // react/jsx-handler-names
@@ -122,6 +125,7 @@ module.exports = {
     // react/jsx-no-comment-textnodes
     // react/jsx-no-literals
     // react/jsx-one-expression-per-line
+    // react/jsx-props-no-spreading
     // react/jsx-sort-default-props
     // react/jsx-sort-props
     // react/jsx-space-before-closing deprecated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1190,6 +1190,11 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+      "integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag=="
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "^7.12.4"
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0"
   }
 }


### PR DESCRIPTION
This is a **BREAKING CHANGE** for React users because this causes new errors for code using React Hooks.

I've also added many a11y rules as warnings, but I might disable some rules if they don't make sense.
So please file an issue if you encounter rules that you feel they don't make sense.