### PR TITLE
feat(react-typescript): disable prop-types

### DIFF
--- a/lib/react-typescript.js
+++ b/lib/react-typescript.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
-    "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }]
+    "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
+    "react/prop-types": ["off", {}]
   }
 };

--- a/test/fixtures/react-typescript/ok.tsx
+++ b/test/fixtures/react-typescript/ok.tsx
@@ -4,7 +4,7 @@ interface Props {
   name: string;
 }
 
-const Foo:React.FC<Props> = ({name}) => <p>Foo{name}</p>;
+const Foo: React.FC<Props> = ({name}) => <p>Foo{name}</p>;
 
 const Component = () => <Foo name="bar" />;
 export default Component;

--- a/test/fixtures/react-typescript/ok.tsx
+++ b/test/fixtures/react-typescript/ok.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import * as React from 'react';
 
 interface Props {
   name: string;
 }
 
-const Foo = ({name}: Props) => <p>Foo{name}</p>;
+const Foo:React.FC<Props> = ({name}) => <p>Foo{name}</p>;
 
 const Component = () => <Foo name="bar" />;
 export default Component;


### PR DESCRIPTION
When Using React and TypeScript, `propTypes` is rarely used.
I want to disable `react/prop-types`