### PR TITLE
feat(typescript): disable typescript-eslint/ban-ts-ignore

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -21,6 +21,7 @@ module.exports = {
     "@typescript-eslint/unified-signatures": "warn",
     "@typescript-eslint/indent": ["warn", 2, { SwitchCase: 1 }],
 
+    "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",

--- a/test/fixtures/typescript/ok.ts
+++ b/test/fixtures/typescript/ok.ts
@@ -23,3 +23,6 @@ class Bar {
 
 const bar: BarInterface = new Bar('bar');
 bar.getName();
+
+// @ts-ignore
+const num: number = '10';


### PR DESCRIPTION
I know `@ts-ignore` isn't good, but sometimes we need it at refactoring legacy code and using npm packages that have wrong type definitions, and so on.
So I want to allow to use `@ts-ignore`.