### PR TITLE
Update ESLint version to v6.4.0 and enable new rules

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -16,6 +16,7 @@ module.exports = {
     // =======
 
     // Best Practices
+    "default-param-last": "error",
     "no-caller": "error",
     "no-eval": "error",
     "no-extend-native": "error",
@@ -43,6 +44,7 @@ module.exports = {
     "no-useless-concat": "error",
     "no-void": "error",
     "no-with": "error",
+    "prefer-regex-literals": "error",
     radix: "error",
     "wrap-iife": ["error", "any"],
     // no-case-declarations
@@ -57,6 +59,7 @@ module.exports = {
     // Possible Errors
     "no-async-promise-executor": "error",
     "no-extra-parens": ["error", "functions"],
+    "no-import-assign": "error",
     "require-atomic-updates": "error",
     "valid-typeof": [
       "error",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/react": "^16.9.9",
-    "eslint": "^6.3.0",
+    "eslint": "^6.4.0",
     "mocha": "^6.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
@@ -36,7 +36,7 @@
     "typescript": "^3.6.4"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0",
+    "eslint": "^6.4.0",
     "typescript": "^3.3.3333"
   },
   "dependencies": {

--- a/test/base-test.js
+++ b/test/base-test.js
@@ -13,8 +13,11 @@ describe("base", () => {
           "no-redeclare",
           "getter-return",
           "no-self-assign",
+          "no-import-assign",
           "require-atomic-updates",
-          "no-async-promise-executor"
+          "no-async-promise-executor",
+          "default-param-last",
+          "prefer-regex-literals"
         ],
         warnings: ["no-useless-return"]
       },

--- a/test/fixtures/base/error.js
+++ b/test/fixtures/base/error.js
@@ -1,3 +1,5 @@
+import mod from './mod';
+
 var foo = {};
 var foo = {};
 const obj = {
@@ -9,6 +11,18 @@ const obj = {
 
 obj.a = obj.a;
 
+mod = 'mod';
+console.log(mod);
+
 (async () => {
   obj.a += await new Promise(async (r) => r(10));
 })();
+
+function fn(a, b = 'b', c) {
+  // noop
+}
+fn();
+
+const regexp = new RegExp('foo|bar');
+console.log(regexp);
+


### PR DESCRIPTION
**PLEASE DO NOT SQUASH MERGE**

This PR contains some BREAKING CHANGES so I'd like to release a new version that doesn't include this.
~**Please do not merge this before publishing a new version.**~
I've released a new version already

This PR enables rules added ESLint v6.4.0 so this has the following BREAKING CHANGES

- Update your ESLint version to v6.4.0
- You might see new errors after updating `cybozu/eslint-config`

https://eslint.org/blog/2019/09/eslint-v6.4.0-released