### PR TITLE
fix: use detect option for React version

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -6,6 +6,11 @@ module.exports = {
       jsx: true
     }
   },
+  settings: {
+    react: {
+      version: "detect"
+    }
+  },
   rules: {
     // =======
     // Error

--- a/package-lock.json
+++ b/package-lock.json
@@ -2832,6 +2832,17 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "react": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
+      "integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-is": {
       "version": "16.10.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mocha": "^6.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
+    "react": "^16.10.2",
     "standard-version": "^7.0.0",
     "typescript": "^3.6.4"
   },


### PR DESCRIPTION
Currently, we don't specify any version for React so we see the following warning when running ESLint with a preset includes `react`.

```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```

In this PR, I use `detect` option for the warning, which is an option to detect a version from the installed React version.
In addition to that, I've added `react` as a `devDependency` because of detecting React version.