### PR TITLE
fix: fail node/no-missing-import rule on TS files

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1,5 +1,11 @@
 module.exports = {
   extends: ["plugin:node/recommended"],
+  settings: {
+    node: {
+      // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-import.md#tryextensions
+      tryExtensions: [".js", ".json", ".node", ".ts", ".jsx", ".tsx"]
+    }
+  },
   rules: {
     "no-console": "off"
   }

--- a/test/fixtures/node-typescript/error.ts
+++ b/test/fixtures/node-typescript/error.ts
@@ -1,0 +1,2 @@
+import { sum } from "./sum2";
+sum();

--- a/test/fixtures/node-typescript/ok.ts
+++ b/test/fixtures/node-typescript/ok.ts
@@ -1,0 +1,3 @@
+// prettier-ignore
+import { sum } from "./sum";
+sum();

--- a/test/fixtures/node-typescript/sum.ts
+++ b/test/fixtures/node-typescript/sum.ts
@@ -1,0 +1,3 @@
+export const sum = () => {
+  return 10;
+};

--- a/test/lib/runLintWithFixtures.js
+++ b/test/lib/runLintWithFixtures.js
@@ -18,7 +18,6 @@ const runLintWithFixtures = (type, configFile = `lib/${type}.js`) => {
   const targetDir = path.resolve(__dirname, "..", "fixtures", type);
   const lintResult = cli.executeOnFiles([targetDir]);
   // console.log(JSON.stringify(lintResult, null, 2));
-
   return lintResult.results.reduce((results, { filePath, messages }) => {
     // strip path
     const fileName = filePath.replace(`${targetDir}/`, "");

--- a/test/node-typescript.js
+++ b/test/node-typescript.js
@@ -1,0 +1,19 @@
+const assert = require("assert");
+const runLintWithFixtures = require("./lib/runLintWithFixtures");
+
+describe("node-typescript", () => {
+  it("should get expected errors and warninigs", () => {
+    // We use react presets in order to support ES2017 syntax
+    const result = runLintWithFixtures(
+      "node-typescript",
+      "presets/node-typescript-prettier.js"
+    );
+    assert.deepStrictEqual(result, {
+      "ok.ts": {},
+      "sum.ts": {},
+      "error.ts": {
+        errors: ["node/no-missing-import"]
+      }
+    });
+  });
+});


### PR DESCRIPTION
[node/no-missing-import](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-import.md) has been added into `plugin:node/recommended` since v10.

The rule only searches `[".js", ".json", ".node"]` extensions so the rule is always failed with TypeScript(`.ts`) files.

This PR fixes the problem.
I'd like to merge and release this as soon as possible because now most PRs for `cybozu/eslint-config` v9 are being failed due to this 🙏 