### PR TITLE
ci: run GitHub Actions for branch push by Renovate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,9 @@ name: lint
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'renovate/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'renovate/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently, Renovate doesn't work as I expected, and I guess that the reason is that we only run GItHub Actions for branches that has a PR, which causes a pending commit status and Renovate skips creating a PR due to the status.

To prove this is correct, I've changed to run GitHub Actions for branches that Renovate creates. This is not a permanent solution, which is only for testing.