### PR TITLE
chore!: drop Node v10 support because of EOL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,3 @@
-
 name: lint
 
 on:
@@ -10,14 +9,20 @@ on:
 
 jobs:
   build:
-    name: Node.js ubuntu-latest 12.x
-    runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.os }} ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        os: [ubuntu-latest]
+    
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 12.x
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: ${{ matrix.node-version }}
     - name: npm ci, and npm run lint
       run: |
         npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
-
 name: test
 
 on:
@@ -10,13 +9,12 @@ on:
 
 jobs:
   build:
-
     name: Node.js ${{ matrix.os }} ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cybozu/eslint-config",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "repository": "cybozu/eslint-config",
   "homepage": "https://github.com/cybozu/eslint-config",

--- a/test/fixtures/node/error.js
+++ b/test/fixtures/node/error.js
@@ -1,6 +1,7 @@
 // prettier-ignore
 require('./unknown');
 
+
 (async () => {
   try {
     await new Promise(r => r);
@@ -8,3 +9,5 @@ require('./unknown');
     console.log(1n);
   }
 })();
+
+exports = {};

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -6,10 +6,7 @@ describe("node", () => {
     const result = await runLintWithFixtures("node");
     assert.deepStrictEqual(result, {
       "error.js": {
-        errors: [
-          "node/no-missing-require",
-          "node/no-unsupported-features/es-syntax",
-        ],
+        errors: ["node/no-missing-require", "node/no-exports-assign"],
       },
       "ok.js": {},
     });


### PR DESCRIPTION
I've made several changes based on #423
- [x] Drop Node v10 support
- [x] Update lint action to use Node v14
- [x] Update test action to use Node v12, v14, v16

I've also tidied up some extra line and space and update lint.yml so that it'll make updating the Node version easier in the future.

This will closes #423 