### PR TITLE
docs: Removed the cautionary statement about a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ module.exports = {
   - Including `@typescript-eslint/eslint-plugin`
 - `@cybozu/eslint-config/presets/react`
   - Including `eslint-plugin-react`, `eslint-plugin-jsx-ally` and `eslint-plugin-react-hooks`
-  - ⚠️ A11y rules are being defined as warnings, which is an experimental so we might change the rules in later
 - `@cybozu/eslint-config/presets/react-typescript`
   - Including `@cybozu/eslint-config/presets/typescript` and `@cybozu/eslint-config/presets/react`
 - `@cybozu/eslint-config/presets/es5`


### PR DESCRIPTION
https://github.com/cybozu/eslint-config/blob/master/CHANGELOG.md#1300-2021-04-28 
With this change, the description of a11y is no longer needed.