### PR TITLE
feat!: React 17 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,13 @@ module.exports = {
 ```
 
 We also provide `@cybozu/eslint-config/presets/kintone-customize-es5-prettier` to use it with `prettier`.
+
+## ⚠️ Class JSX Syntax
+
+`@cybozu/eslint-config` is intented to be used with the [New JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). If you want to use the Classic JSX Transform (`React.createElement`), please enable the `react/jsx-uses-react` rule on your own.
+
+```json
+rules: {
+  "react/jsx-uses-react": "error"
+}
+```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ To use the presets, you have to install `prettier`. We only support Prettier v2 
 
 **Currently, we don't support customized Prettier config**
 
+## React Support
+
+### ⚠️ Classic JSX Syntax
+
+`@cybozu/eslint-config` is intented to be used with the [New JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). If you want to use the Classic JSX Transform (`React.createElement`), please enable the `react/jsx-uses-react` rule on your own.
+
+```json
+rules: {
+  "react/jsx-uses-react": "error"
+}
+```
+
 ## For kintone customize developers
 
 `@cybozu/eslint-config/preset/kintone-customize-es5` is a preset for kintone customize(plug-in) developers, which is based on `preset/es5` and add some `globals` for kintone.
@@ -123,13 +135,3 @@ module.exports = {
 ```
 
 We also provide `@cybozu/eslint-config/presets/kintone-customize-es5-prettier` to use it with `prettier`.
-
-## ⚠️ Class JSX Syntax
-
-`@cybozu/eslint-config` is intented to be used with the [New JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). If you want to use the Classic JSX Transform (`React.createElement`), please enable the `react/jsx-uses-react` rule on your own.
-
-```json
-rules: {
-  "react/jsx-uses-react": "error"
-}
-```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To use the presets, you have to install `prettier`. We only support Prettier v2 
 
 `@cybozu/eslint-config` is intented to be used with the [New JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). If you want to use the Classic JSX Transform (`React.createElement`), please enable the `react/jsx-uses-react` rule on your own.
 
-```json
+```js
 rules: {
   "react/jsx-uses-react": "error"
 }

--- a/lib/react.js
+++ b/lib/react.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: ["react", "react-hooks", "jsx-a11y"],
-  extends: ["plugin:react/recommended"],
+  extends: ["plugin:react/recommended", "plugin:react/jsx-runtime"],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/test/fixtures/react/ok.jsx
+++ b/test/fixtures/react/ok.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Foo = () => <p>Foo</p>;
 
 const Component = () => <Foo />;


### PR DESCRIPTION
Fixed #450

I added "plugin:react/jsx-runtime" for React 17 based on the following statement.

> If you are using the new JSX transform from React 17, extend react/jsx-runtime in your eslint config (add "plugin:react/jsx-runtime" to "extends") to disable the relevant rules.

https://github.com/yannickcr/eslint-plugin-react#configuration 