### PR TITLE
BREAKING CHANGE(react): add react/no-unstable-nested-components rule as error

### DIFF
--- a/lib/react.js
+++ b/lib/react.js
@@ -36,6 +36,7 @@ module.exports = {
     "react/no-this-in-sfc": "error",
     // react/no-unescaped-entities
     // react/no-unknown-property
+    "react/no-unstable-nested-components": "error",
     "react/no-will-update-set-state": "error",
     "react/prefer-es6-class": "error",
     "react/prefer-stateless-function": [


### PR DESCRIPTION
To prevent performance degradation, I added a rule to prohibit defining components within components in React.
Defining components within components can cause unnecessary re-rendering. 

- Enable: [`react/no-unstable-nested-components`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md)