### PR TITLE
fix: false positive of no-shadow rule for TypeScript

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -29,6 +29,9 @@ module.exports = {
     "@typescript-eslint/prefer-interface": "off",
     "@typescript-eslint/prefer-namespace-keyword": "off",
 
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error",
+
     // These rules are required type information,
     // which means these can be checked without parserOptions.project
     // "@typescript-eslint/no-for-in-array": "error",

--- a/test/fixtures/react-typescript/error.tsx
+++ b/test/fixtures/react-typescript/error.tsx
@@ -8,3 +8,9 @@ const Foo = ({name}: Props) => <p>Foo{...name}</p>;
 
 const Component = () => <Foo name={['bar', 'foo']} />;
 export default Component;
+
+const shadow: number = 1;
+const shadowingFunc: () => number = () => {
+  const shadow: number = 2;
+  return shadow;
+};

--- a/test/fixtures/typescript/error.ts
+++ b/test/fixtures/typescript/error.ts
@@ -1,1 +1,7 @@
 const nums: Array<number> = [1, 2, 3];
+
+const shadow: number = 1;
+const shadowingFunc: () => number = () => {
+  const shadow: number = 2;
+  return shadow;
+};

--- a/test/react-typescript-test.js
+++ b/test/react-typescript-test.js
@@ -11,7 +11,10 @@ describe("react-typescript", () => {
     assert.deepStrictEqual(result, {
       "ok.tsx": {},
       "error.tsx": {
-        errors: ["@typescript-eslint/array-type"],
+        errors: [
+          "@typescript-eslint/array-type",
+          "@typescript-eslint/no-shadow",
+        ],
       },
       "warning.tsx": {
         warnings: [

--- a/test/typescript-test.js
+++ b/test/typescript-test.js
@@ -8,7 +8,10 @@ describe("typescript", () => {
     assert.deepStrictEqual(result, {
       "ok.ts": {},
       "error.ts": {
-        errors: ["@typescript-eslint/array-type"],
+        errors: [
+          "@typescript-eslint/array-type",
+          "@typescript-eslint/no-shadow",
+        ],
       },
       "warning.ts": {
         warnings: [


### PR DESCRIPTION
I have added code that avoids the `"false positive"` problem of the eslint/no-shadow rule for TypeScript code discussed in `"typescript-eslint"` issue below.

Please see this issue for more detailed information. 
https://github.com/typescript-eslint/typescript-eslint/issues/2483