### PR TITLE
feat: add `kintone-customize` presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,24 @@ rules: {
 
 ## For kintone customize developers
 
-`@cybozu/eslint-config/preset/kintone-customize-es5` is a preset for kintone customize(plug-in) developers, which is based on `preset/es5` and add some `globals` for kintone.
+We also provide presets for kintone customize/plug-in developers, which include some `globals` for kintone.
+
+### Usage
 
 ```js
+// .eslintrc.js
 module.exports = {
-  extends: "@cybozu/eslint-config/presets/kintone-customize-es5"
+  extends: "@cybozu/eslint-config/presets/kintone-customize"
 };
 ```
 
-We also provide `@cybozu/eslint-config/presets/kintone-customize-es5-prettier` to use it with `prettier`.
+### Presets
+
+- `@cybozu/eslint-config/preset/kintone-customize`
+  - Preset for kintone customize/plugin-in development
+- `@cybozu/eslint-config/preset/kintone-customize-prettier`
+  - Preset for kintone customize/plugin-in development including `prettier` config
+- `@cybozu/eslint-config/preset/kintone-customize-es5`
+  - Preset for kintone customize/plugin-in development in ES5
+- `@cybozu/eslint-config/preset/kintone-customize-es5-prettier`
+  - Preset for kintone customize/plugin-in development in ES5 including `prettier` config

--- a/presets/kintone-customize-prettier.js
+++ b/presets/kintone-customize-prettier.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: [
+    "../lib/base.js",
+    "../lib/kintone.js",
+    "../globals/kintone.js",
+    "../lib/prettier.js",
+  ],
+};

--- a/presets/kintone-customize.js
+++ b/presets/kintone-customize.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["../lib/base.js", "../lib/kintone.js", "../globals/kintone.js"],
+};

--- a/test/presets-test.js
+++ b/test/presets-test.js
@@ -55,6 +55,25 @@ describe("presets", () => {
       );
     });
   });
+  describe("kintone-customize", () => {
+    it("should be able to use kintone-customize as well as lib/base", async () => {
+      assert.deepStrictEqual(
+        await runLintWithFixtures("base"),
+        await runLintWithFixtures("base", "presets/kintone-customize.js"),
+      );
+    });
+  });
+  describe("kintone-customize-prettier", () => {
+    it("should be able to use kintone-customize-prettier as well as lib/prettier", async () => {
+      assert.deepStrictEqual(
+        await runLintWithFixtures("prettier"),
+        await runLintWithFixtures(
+          "prettier",
+          "presets/kintone-customize-prettier.js",
+        ),
+      );
+    });
+  });
   describe("prettier", () => {
     it("should be able to use prettier as well as lib/prettier", async () => {
       assert.deepStrictEqual(


### PR DESCRIPTION
## Why

Because Kintone has dropped supporting IE, we promote using the >ES6 edition in Kintone customize/plugin-in.

## What

- add `kintone-customize` and `kintone-customize-prettier` presets
- update README.md