### PR TITLE
ci: update node versions in ci test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
### Outline
Changed node versions used in CI test.
- before : `[16.x, 18.x, 20.x]`
- after : `[18.x, 20.x, 22.x]`

### Details
The current(2024/09) support status of each Node version is as follows
- 16 : deprecated
- 18 : maintenance mode
- 20 : Active as LTS
- 22 : cuttent version

So, CI test should be run in three environments: v18, v20, and v22.


### Note
`engines` in `package.json` has been `>= 18` for some time, so it looks good to drop v16.