### PR TITLE
feat: Add base config to flat preset

### DIFF
--- a/flat/presets/base.js
+++ b/flat/presets/base.js
@@ -1,0 +1,9 @@
+const base = require("../lib/base.js");
+
+/**
+ * @type { import("eslint").Linter.Config[] }
+ */
+module.exports = [
+  { files: ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"] },
+  ...base(),
+];

--- a/test/flat/preset-base-test.js
+++ b/test/flat/preset-base-test.js
@@ -1,0 +1,13 @@
+const assert = require("assert");
+const basePreset = require("../../flat/presets/react-prettier");
+const base = require("../../flat/lib/prettier");
+const runLintWithFixturesFlat = require("../lib/runLintWithFixturesFlat");
+
+describe("flat preset react-prettier", () => {
+  it("should be able to use react-prettier as well as lib/prettier", async () => {
+    assert.deepStrictEqual(
+      await runLintWithFixturesFlat("prettier", base()),
+      await runLintWithFixturesFlat("prettier", basePreset)
+    );
+  });
+});

--- a/test/flat/preset-base-test.js
+++ b/test/flat/preset-base-test.js
@@ -1,13 +1,13 @@
 const assert = require("assert");
-const basePreset = require("../../flat/presets/react-prettier");
-const base = require("../../flat/lib/prettier");
+const basePreset = require("../../flat/presets/base");
+const base = require("../../flat/lib/base");
 const runLintWithFixturesFlat = require("../lib/runLintWithFixturesFlat");
 
-describe("flat preset react-prettier", () => {
-  it("should be able to use react-prettier as well as lib/prettier", async () => {
+describe("flat preset base", () => {
+  it("should be able to use base as well as lib/base", async () => {
     assert.deepStrictEqual(
-      await runLintWithFixturesFlat("prettier", base()),
-      await runLintWithFixturesFlat("prettier", basePreset)
+      await runLintWithFixturesFlat("base", base()),
+      await runLintWithFixturesFlat("base", basePreset)
     );
   });
 });


### PR DESCRIPTION
## Outline
Introduce a new `base` preset under `flat/preset` that directly provides the config from `flat/lib`.

## Details
In the previous Config system, users could easily extend the `lib/base` config by simply writing `{extends: '@cybozu'}`. However, there is no equivalent preset for FlatConfig that distributes only the rules from `flat/lib/base`.

As a result, users who previously wrote their config as `{extends: '@cybozu'}` have no alternative method in FlatConfig.

To resolve this issue, I created a new `flat/preset/base.js` that extends only the `flat/lib/base` rules.Additionally, I added tests to ensure that `flat/lib/base` and `flat/preset/base.js` are equivalent.