### PR TITLE
docs: fix README typo in config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module.exports = {
 > [!NOTE]
 > Flat Config support is experimental. The applicable rules and scope may have changed.
 
-Put it into your `.eslint.config.js`
+Put it into your `eslint.config.js`
 
 ```js
 const config = require("@cybozu/eslint-config/flat/presets/react-typescript-prettier")


### PR DESCRIPTION
### Outline
README contains `.eslint.config.js`, but the correct name is `eslint.config.js`(leading dot is not necessary).