### PR TITLE
add @eslint/css & baseline rules

### DIFF
--- a/flat/lib/css-baseline.js
+++ b/flat/lib/css-baseline.js
@@ -1,0 +1,28 @@
+const css = require("@eslint/css");
+
+/**
+ * @return { import("eslint").Linter.FlatConfig[] }
+ */
+module.exports = function cssBaseline() { return [
+  {
+    plugins: {
+      css: css.default,
+    },
+    language: "css/css",
+    // the same error recovery algorithm as the browser
+    // https://eslint.org/blog/2025/02/eslint-css-support/#tolerant-parsing-support
+    languageOptions: {
+        tolerant: true,
+    },
+    rules: {
+      "css/no-duplicate-imports": "error",
+      
+      // Lint CSS files to ensure they are using
+      // only Baseline Widely available features:
+      "css/use-baseline": ["warn", {
+        available: "widely"
+      }]
+    },
+  },
+]
+};

--- a/flat/presets/css-baseline.js
+++ b/flat/presets/css-baseline.js
@@ -1,0 +1,9 @@
+const cssBaseline = require("../lib/css-baseline.js");
+
+/**
+ * @type { import("eslint").Linter.Config[] }
+ */
+module.exports = [
+  { files: ["**/*.css"] },
+  ...cssBaseline(),
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "typescript-eslint": "^8.22.0"
       },
       "devDependencies": {
+        "@eslint/css": "^0.9.0",
         "@types/react": "^18.3.23",
         "eslint": "^9.19.0",
         "mocha": "^11.7.1",
@@ -237,6 +238,75 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
       "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.9.0.tgz",
+      "integrity": "sha512-fq8hYnjipdzVDSU/bXqv7qlvdjDA27Nq7DhQXzlPElLlVon3lnKovIM/6HaUrq1bz7EPgRobr+vOhpeM6z0X4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.14.0",
+        "@eslint/css-tree": "^3.6.1",
+        "@eslint/plugin-kit": "^0.3.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.1.tgz",
+      "integrity": "sha512-5DIsBME23tUQD5zHD+T38lC2DG4jB8x8JRa+yDncLne2TIZA0VuCpcSazOX1EC+sM/q8w24qeevXfmfsIxAeqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.21.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/plugin-kit": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -4137,6 +4207,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
+      "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -5729,6 +5806,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "cybozu",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/css": "^0.9.0",
     "@types/react": "^18.3.23",
     "eslint": "^9.19.0",
     "mocha": "^11.7.1",

--- a/test/fixtures/css-baseline/error.css
+++ b/test/fixtures/css-baseline/error.css
@@ -1,0 +1,22 @@
+/* CSS with duplicate imports and non-widely available features */
+
+/* duplicate imports are subject to error */
+@import url("styles.css");
+@import url("styles.css");
+
+.container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  /* non-widely available warning */
+  container-type: inline-size;
+  /* non-widely available warning */
+  backdrop-filter: blur(10px);
+  aspect-ratio: 16/9;
+}
+
+.modern-feature {
+  /* non-widely available warning: oklch */
+  color: oklch(0.7 0.2 180);
+  /* non-widely available warning */
+  accent-color: blue;
+}

--- a/test/fixtures/css-baseline/ok.css
+++ b/test/fixtures/css-baseline/ok.css
@@ -1,0 +1,14 @@
+/* Valid CSS using widely available features */
+.container {
+  display: flex;
+  margin: 10px;
+  padding: 20px;
+  background-color: #ffffff;
+  border-radius: 4px;
+}
+
+.button {
+  color: #000;
+  font-size: 16px;
+  text-align: center;
+}

--- a/test/flat/preset-css-baseline-test.js
+++ b/test/flat/preset-css-baseline-test.js
@@ -1,0 +1,16 @@
+const assert = require("assert");
+const runLintWithFixturesFlat = require("../lib/runLintWithFixturesFlat");
+const cssBaseline = require("../../flat/presets/css-baseline");
+
+describe("flat preset css-baseline", () => {
+  it("should get expected errors and warnings", async () => {
+    const result = await runLintWithFixturesFlat("css-baseline", cssBaseline);
+    assert.deepStrictEqual(result, {
+      "ok.css": {},
+      "error.css": {
+        errors: ["css/no-duplicate-imports"],
+        warnings: ["css/use-baseline", "css/use-baseline", "css/use-baseline", "css/use-baseline"],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## 🏁 Outline
CSS の Basline Widely Available な機能を静的解析するルールセットを追加しました。

## 📝 Description

`@eslint/css` を追加し、共通で持つ分として最低限だと思われる以下のルールを追加しています。

- css/use-baseline: Widely Available 未満のCSS featureを使用した場合に warning
- css/no-duplicate-imports: 重複する `@import` がある場合 error
- tolerant parsing: ブラウザのエラー回復動作に合わせる

## ✅ Test
flat config 構文自体の整合性をチェックするテスト、css/use-baseline、css/no-duplicate-imports に対するテストを追加しています。
[test/flat/preset-css-baseline-test.js](https://github.com/cybozu/eslint-config/compare/css/baseline?expand=1#diff-7745f7f37b1920d5400d8d07b0da7e5be2d5cea4f44c037e0d79de752974a5c4)