### PR TITLE
chore: update Node.js versions in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 'renovate/**'
+      - "renovate/**"
   pull_request:
 
 jobs:
@@ -14,18 +14,18 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm ci, and npm test
-      run: |
-        npm ci
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm ci, and npm test
+        run: |
+          npm ci
+          npm test
+        env:
+          CI: true


### PR DESCRIPTION
## Outline

Update Node.js versions in test workflow.

## Details

Removed `v18` as it reached End of Life (EOL). Instead, added `v24` which is the latest LTS version currently available.
