### PR TITLE
fix(deps): move @eslint/css from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "24.1.0",
       "license": "MIT",
       "dependencies": {
+        "@eslint/css": "^0.10.0",
         "@eslint/js": "^9.31.0",
         "@stylistic/eslint-plugin-ts": "^3.1.0",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
@@ -24,7 +25,6 @@
         "typescript-eslint": "^8.38.0"
       },
       "devDependencies": {
-        "@eslint/css": "^0.10.0",
         "@types/react": "^18.3.23",
         "eslint": "^9.31.0",
         "mocha": "^11.7.1",
@@ -291,7 +291,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.10.0.tgz",
       "integrity": "sha512-pHoYRWS08oeU0qVez1pZCcbqHzoJnM5VMtrxH2nWDJ0ukq9DkwWV1BTY+PWK+eWBbndN9W0O9WjJTyAHsDoPOg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.14.0",
@@ -306,7 +305,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.1.tgz",
       "integrity": "sha512-5DIsBME23tUQD5zHD+T38lC2DG4jB8x8JRa+yDncLne2TIZA0VuCpcSazOX1EC+sM/q8w24qeevXfmfsIxAeqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.21.0",
@@ -320,7 +318,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
       "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -4573,7 +4570,6 @@
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
       "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/memorystream": {
@@ -6194,7 +6190,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "author": "cybozu",
   "license": "MIT",
   "devDependencies": {
-    "@eslint/css": "^0.10.0",
     "@types/react": "^18.3.23",
     "eslint": "^9.31.0",
     "mocha": "^11.7.1",
@@ -43,6 +42,7 @@
     "typescript": ">=4.7.5 || ^5.0.0"
   },
   "dependencies": {
+    "@eslint/css": "^0.10.0",
     "@eslint/js": "^9.31.0",
     "@stylistic/eslint-plugin-ts": "^3.1.0",
     "@typescript-eslint/eslint-plugin": "^8.38.0",


### PR DESCRIPTION
## Summary

Move @eslint/css from devDependencies to dependencies to fix module resolution errors when using
flat/presets/css-baseline.js.

## Problem

When packages that depend on @cybozu/eslint-config try to use flat/presets/css-baseline.js, they encounter the
error:
`Error: Cannot find module '@eslint/css'`

This happens because @eslint/css was listed in devDependencies, which are not installed for packages that depend
on this config.

## Solution

Moved @eslint/css from devDependencies to dependencies since it's required at runtime by the css-baseline
preset.

## Changes

- Moved @eslint/css@^0.10.0 from devDependencies to dependencies