### PR TITLE
fix: changed to explicitly add the `files` property in every config.

### DIFF
--- a/flat/presets/base.js
+++ b/flat/presets/base.js
@@ -1,9 +1,10 @@
 const base = require("../lib/base.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"] },
-  ...base(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base()],
+  ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"],
+);

--- a/flat/presets/css-baseline.js
+++ b/flat/presets/css-baseline.js
@@ -1,6 +1,7 @@
 const cssBaseline = require("../lib/css-baseline.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [{ files: ["**/*.css"] }, ...cssBaseline()];
+module.exports = attachFilesPropForConfig([...cssBaseline()], ["**/*.css"]);

--- a/flat/presets/es5-prettier.js
+++ b/flat/presets/es5-prettier.js
@@ -1,7 +1,11 @@
 const es5 = require("../lib/es5.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [...es5(), ...prettier()];
+module.exports = attachFilesPropForConfig(
+  [...es5(), ...prettier()],
+  ["**/*.{js,cjs,ts,cts,jsx,tsx}"],
+);

--- a/flat/presets/es5.js
+++ b/flat/presets/es5.js
@@ -1,6 +1,10 @@
 const es5 = require("../lib/es5.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [...es5()];
+module.exports = attachFilesPropForConfig(
+  [...es5()],
+  ["**/*.{js,cjs,ts,cts,jsx,tsx}"],
+);

--- a/flat/presets/kintone-customize-es5-prettier.js
+++ b/flat/presets/kintone-customize-es5-prettier.js
@@ -2,13 +2,12 @@ const es5 = require("../lib/es5.js");
 const kintoneEs5 = require("../lib/kintone-es5.js");
 const kintoneGlobals = require("../globals/kintone.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,jsx}"] },
-  ...es5({ overrideGlobals: kintoneGlobals }),
-  ...kintoneEs5(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...es5({ overrideGlobals: kintoneGlobals }), ...kintoneEs5(), ...prettier()],
+  ["**/*.{js,cjs,ts,cts,jsx,tsx}"],
+);

--- a/flat/presets/kintone-customize-es5.js
+++ b/flat/presets/kintone-customize-es5.js
@@ -1,12 +1,12 @@
 const es5 = require("../lib/es5.js");
 const kintoneEs5 = require("../lib/kintone-es5.js");
 const kintoneGlobals = require("../globals/kintone.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,jsx}"] },
-  ...es5({ overrideGlobals: kintoneGlobals }),
-  ...kintoneEs5(),
-];
+module.exports = attachFilesPropForConfig(
+  [...es5({ overrideGlobals: kintoneGlobals }), ...kintoneEs5()],
+  ["**/*.{js,cjs,ts,cts,jsx,tsx}"],
+);

--- a/flat/presets/kintone-customize-prettier.js
+++ b/flat/presets/kintone-customize-prettier.js
@@ -1,11 +1,11 @@
 const kintone = require("../lib/kintone.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"] },
-  ...kintone(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...kintone(), ...prettier()],
+  ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"],
+);

--- a/flat/presets/kintone-customize.js
+++ b/flat/presets/kintone-customize.js
@@ -1,9 +1,10 @@
 const kintone = require("../lib/kintone.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"] },
-  ...kintone(),
-];
+module.exports = attachFilesPropForConfig(
+  [...kintone()],
+  ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"],
+);

--- a/flat/presets/node-prettier.js
+++ b/flat/presets/node-prettier.js
@@ -1,13 +1,12 @@
 const base = require("../lib/base.js");
 const node = require("../lib/node.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,tsx,jsx,mts,cts}"] },
-  ...base(),
-  ...node(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...node(), ...prettier()],
+  ["**/*.{js,cjs,mjs,ts,tsx,jsx,mts,cts}"],
+);

--- a/flat/presets/node-typescript-prettier.js
+++ b/flat/presets/node-typescript-prettier.js
@@ -3,15 +3,12 @@ const node = require("../lib/node.js");
 const prettier = require("../lib/prettier.js");
 const typescript = require("../lib/typescript.js");
 const nodeTypescript = require("../lib/node-typescript.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,cts,mts,jsx,tsx}"] },
-  ...base(),
-  ...node(),
-  ...typescript(),
-  ...nodeTypescript(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...node(), ...typescript(), ...nodeTypescript(), ...prettier()],
+  ["**/*.{js,cjs,mjs,ts,cts,mts,jsx,tsx}"],
+);

--- a/flat/presets/node.js
+++ b/flat/presets/node.js
@@ -1,11 +1,11 @@
 const base = require("../lib/base.js");
 const node = require("../lib/node.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"] },
-  ...base(),
-  ...node(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...node()],
+  ["**/*.{js,cjs,mjs,ts,mts,cts,jsx,tsx}"],
+);

--- a/flat/presets/prettier.js
+++ b/flat/presets/prettier.js
@@ -1,7 +1,11 @@
 const base = require("../lib/base.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [...base(), ...prettier()];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...prettier()],
+  ["**/*.{js,cjs,mjs,ts,tsx,jsx,mts,cts}"],
+);

--- a/flat/presets/react-prettier.js
+++ b/flat/presets/react-prettier.js
@@ -1,13 +1,12 @@
 const base = require("../lib/base.js");
 const react = require("../lib/react.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,mjs,cjs,jsx}"] },
-  ...base(),
-  ...react(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...react(), ...prettier()],
+  ["**/*.{js,mjs,cjs,jsx}"],
+);

--- a/flat/presets/react-typescript-prettier.js
+++ b/flat/presets/react-typescript-prettier.js
@@ -3,15 +3,12 @@ const react = require("../lib/react.js");
 const typescript = require("../lib/typescript.js");
 const reactTypescript = require("../lib/react-typescript.js");
 const prettier = require("../lib/prettier.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,cts,mts,jsx,tsx}"] },
-  ...base(),
-  ...react(),
-  ...reactTypescript(),
-  ...typescript(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...react(), ...reactTypescript(), ...typescript(), ...prettier()],
+  ["**/*.{js,cjs,mjs,ts,cts,mts,jsx,tsx}"],
+);

--- a/flat/presets/react-typescript.js
+++ b/flat/presets/react-typescript.js
@@ -2,14 +2,12 @@ const base = require("../lib/base.js");
 const react = require("../lib/react.js");
 const typescript = require("../lib/typescript.js");
 const reactTypescript = require("../lib/react-typescript.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,cts,mts,tsx,jsx}"] },
-  ...base(),
-  ...react(),
-  ...reactTypescript(),
-  ...typescript(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...react(), ...reactTypescript(), ...typescript()],
+  ["**/*.{js,cjs,mjs,ts,cts,mts,tsx,jsx}"],
+);

--- a/flat/presets/react.js
+++ b/flat/presets/react.js
@@ -1,7 +1,11 @@
 const base = require("../lib/base.js");
 const react = require("../lib/react.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [{ files: ["**/*.{js,cjs,mjs,jsx}"] }, ...base(), ...react()];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...react()],
+  ["**/*.{js,cjs,mjs,jsx}"],
+);

--- a/flat/presets/typescript-prettier.js
+++ b/flat/presets/typescript-prettier.js
@@ -1,13 +1,12 @@
 const base = require("../lib/base.js");
 const prettier = require("../lib/prettier.js");
 const typescript = require("../lib/typescript.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,cts,mts}"] },
-  ...base(),
-  ...typescript(),
-  ...prettier(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...typescript(), ...prettier()],
+  ["**/*.{js,cjs,mjs,ts,cts,mts}"],
+);

--- a/flat/presets/typescript.js
+++ b/flat/presets/typescript.js
@@ -1,11 +1,11 @@
 const base = require("../lib/base.js");
 const typescript = require("../lib/typescript.js");
+const attachFilesPropForConfig = require("../utils/attachFilesPropForConfig.js");
 
 /**
  * @type { import("eslint").Linter.Config[] }
  */
-module.exports = [
-  { files: ["**/*.{js,cjs,mjs,ts,cts,mts}"] },
-  ...base(),
-  ...typescript(),
-];
+module.exports = attachFilesPropForConfig(
+  [...base(), ...typescript()],
+  ["**/*.{js,cjs,mjs,ts,cts,mts}"],
+);

--- a/flat/utils/attachFilesPropForConfig.js
+++ b/flat/utils/attachFilesPropForConfig.js
@@ -1,0 +1,7 @@
+/** @type {(configs: unknown[], files: string[]) => unknown[])} */
+module.exports = function attachFilesPropForConfig(configs, files) {
+  return configs.map((config) => ({
+    ...config,
+    files: Array.isArray(config.files) ? [...config.files, ...files] : files,
+  }));
+};


### PR DESCRIPTION
## Outline

Updated presets to add the target `files` property to all Configuration Objects.

## Details

Since #887, this config now also handles CSS rule presets. When using existing JS/TS rule presets together with CSS rule presets without explicitly specifying the file property, errors could occur.

To avoid these issues, we've added the `files` property to all Configuration Objects under flat/preset and set appropriate values according to each preset.

The logic for uniformly adding the `files` property has been extracted as a new utility: `utils/attachFilesPropForConfig.js`.
