### PR TITLE
ci: harden workflows against supply chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Install pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
     - name: Use Node.js
@@ -42,6 +44,8 @@ jobs:
         node-version: [22.x, 24.x, 'lts/*']
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Install pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'renovate/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for Takumi Guard OIDC authentication
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -20,6 +23,9 @@ jobs:
       with:
         node-version: 'lts/*'
         cache: 'pnpm'
+    - uses: flatt-security/setup-takumi-guard-npm@6d4182745c1e474c35a023573c2612c085be45a4 # v1.2.0
+      with:
+        bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
     - name: pnpm install, and pnpm run lint
       run: |
         pnpm install --frozen-lockfile
@@ -28,6 +34,9 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for Takumi Guard OIDC authentication
     strategy:
       matrix:
         node-version: [22.x, 24.x, 'lts/*']
@@ -40,6 +49,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
+    - uses: flatt-security/setup-takumi-guard-npm@6d4182745c1e474c35a023573c2612c085be45a4 # v1.2.0
+      with:
+        bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
     - name: pnpm install, and pnpm test
       run: |
         pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
           manifest-file: .release-please-manifest.json
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ steps.release.outputs.release_created }}
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
+      - uses: flatt-security/setup-takumi-guard-npm@6d4182745c1e474c35a023573c2612c085be45a4 # v1.2.0
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --frozen-lockfile
         if: ${{ steps.release.outputs.release_created }}
       - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["github>cybozu/renovate-config"]
-}


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions workflows against supply chain attacks: npm packages are now fetched through [Takumi byGMO Guard](https://shisho.dev/docs/ja/t/guard/quickstart/npm), the `GITHUB_TOKEN` is no longer left behind in the workspace, and each job is given only the permissions it needs. Renovate is also removed, as it is no longer used in this repository.

## Changes

### Scan npm packages with Takumi Guard

- Added `flatt-security/setup-takumi-guard-npm` before `pnpm install` in `ci.yml` (lint / test) and `release.yml`
- The action rewrites `registry` in the project `.npmrc` to `https://npm.flatt.tech/`, so packages are fetched through the scanning proxy
- Granted `id-token: write` to the `ci.yml` jobs, which is required for the OIDC-based bot authentication. Without it the action silently falls back to anonymous mode (Tier A blocking only), so this is easy to miss
- Pinned `publishConfig.registry` to `https://registry.npmjs.org/`. The project `.npmrc` takes precedence over the user config written by `actions/setup-node`, so without this `pnpm publish` would be pointed at `npm.flatt.tech`

### Limit what the workflow token can do

- Added `persist-credentials: false` to every `actions/checkout` step, so the `GITHUB_TOKEN` is not written into `.git/config` and left readable by anything running later in the job (including package install scripts)
- Declared explicit `permissions` on the `ci.yml` jobs (`contents: read` plus the `id-token: write` above). Previously they inherited the repository default

### Stop using Renovate

- Removed `renovate.json` and the `renovate/**` push trigger from `ci.yml`

## Note

This requires the repository variable `TAKUMI_GUARD_BOT_ID` to be set. Without it the action falls back to anonymous mode.
